### PR TITLE
Remove the manual declaration of References section

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -200,9 +200,6 @@ Security considerations are included separately in the SCONE protocol documents.
 # IANA Considerations
 This document has no IANA actions.
 
-# References
-{:numbered="false"}
-
 --- back
 
 # Acknowledgments


### PR DESCRIPTION
Removing the manual # References section declaration from the body of the document (The YAML header generates the references). The manual declaration is redundant. Removed the following two lines:
# References 
{:numbered="false"}