### PR TITLE
Update GitHub issue #15 and #18

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -100,18 +100,23 @@ This document uses terms and definitions described in {{I-D.ietf-scone-protocol}
 # Applicability and Manageability Considerations
 
 ## Flow Awareness and Per-Flow Signaling
-As defined in the SCONE Protocol document, throughput advice is associated with the
-flows of UDP datagrams that QUIC exchanges
-(see Section 1 of {{I-D.ietf-scone-protocol}}). Specifically, a flow is identified by
-packets sharing the same address tuple (IP version, source and destination IP
-addresses, and UDP ports) (see Section 3.3 of {{I-D.ietf-scone-protocol}}).
-SCONE signaling operates only over these established flows. To ensure signaling
-correctness, SCONE Network Elements need to be able to unambiguously associate
-throughput advice with specific QUIC flows and maintain context for these flows.
-This flow awareness is critical because throughput advice applies strictly to that specific
-flow of packets on the same address tuple. By maintaining this per-flow context, network
-elements ensure that SCONE packets are routed precisely, enabling applications to receive
-targeted throughput advice while preventing any unintended impact on unrelated traffic.
+As defined in the core SCONE protocol specification {{I-D.ietf-scone-protocol}},
+throughput advice is associated with the flow of QUIC UDP datagrams sharing the
+same address tuple (IP version, source and destination IP addresses, and UDP ports).
+
+Because throughput advice applies strictly to this specific flow, SCONE Network Elements
+need to unambiguously associate their policy limits with the correct QUIC flows. However,
+the act of applying SCONE throughput advice is inherently stateless. To provide advice, a
+network element simply identifies a traversing SCONE packet and updates its value based on
+the configured policy for that flow or network scope, without needing to maintain active
+per-flow state.
+
+While the signaling itself is stateless, managing the operational lifecycle of a SCONE
+deployment requires establishing and maintaining per-flow context. Specifically, to execute
+the monitoring, logging, and conformance evaluation functions detailed later in this document,
+the network element must track the flow's throughput over multiple monitoring periods. This
+per-flow context serves as the operational foundation for validating whether an application is
+adhering to the advised rate and for applying any necessary policy enforcement.
 
 ## QoS awareness
 Quality of Service (QoS) may be enforced by networks through a variety of

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -102,7 +102,7 @@ This document uses terms and definitions described in {{I-D.ietf-scone-protocol}
 ## Flow Awareness and Per-Flow Signaling
 As defined in the SCONE Protocol document, throughput advice is associated with the
 flows of UDP datagrams that QUIC exchanges
-(see Section 1 of {{I-D.ietf-scone-protocol}}). pecifically, a flow is identified by
+(see Section 1 of {{I-D.ietf-scone-protocol}}). Specifically, a flow is identified by
 packets sharing the same address tuple (IP version, source and destination IP
 addresses, and UDP ports) (see Section 3.3 of {{I-D.ietf-scone-protocol}}).
 SCONE signaling operates only over these established flows. To ensure signaling

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -107,7 +107,7 @@ packets sharing the same address tuple (IP version, source and destination IP
 addresses, and UDP ports) (see Section 3.3 of {{I-D.ietf-scone-protocol}}).
 SCONE signaling operates only over these established flows. To ensure signaling
 correctness, SCONE Network Elements need to be able to unambiguously associate
-throughput advice with specific application flows and maintain context for these flows.
+throughput advice with specific QUIC flows and maintain context for these flows.
 This flow awareness is critical because throughput advice applies strictly to that specific
 flow of packets on the same address tuple. By maintaining this per-flow context, network
 elements ensure that SCONE packets are routed precisely, enabling applications to receive

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -99,17 +99,19 @@ This document uses terms and definitions described in {{I-D.ietf-scone-protocol}
 
 # Applicability and Manageability Considerations
 
-## Flow session awareness
-SCONE signaling operates only over established sessions. SCONE Network Elements
-ought to be able to unambiguously associate throughput advice with
-application flows. Each session is bound to an IP address and port,
-ensuring SCONE packets are routed precisely without affecting unrelated traffic.
-
-## Per-Flow Signaling
-Throughput advice is applied on a UDP 4-tuple basis. SCONE Network Elements
-ought to maintain flow-specific context to ensure signaling correctness.
-This enables applications to receive targeted throughput advice while
-preventing unintended impact on unrelated flows.
+## Flow Awareness and Per-Flow Signaling
+As defined in the SCONE Protocol document, throughput advice is associated with the
+flows of UDP datagrams that QUIC exchanges
+(see Section 1 of {{I-D.ietf-scone-protocol}}). pecifically, a flow is identified by
+packets sharing the same address tuple (IP version, source and destination IP
+addresses, and UDP ports) (see Section 3.3 of {{I-D.ietf-scone-protocol}}).
+SCONE signaling operates only over these established flows. To ensure signaling
+correctness, SCONE Network Elements need to be able to unambiguously associate
+throughput advice with specific application flows and maintain context for these flows.
+This flow awareness is critical because throughput advice applies strictly to that specific
+flow of packets on the same address tuple. By maintaining this per-flow context, network
+elements ensure that SCONE packets are routed precisely, enabling applications to receive
+targeted throughput advice while preventing any unintended impact on unrelated traffic.
 
 ## QoS awareness
 Quality of Service (QoS) may be enforced by networks through a variety of


### PR DESCRIPTION
Address GitHub Issue #15 and #18. Specifically, we merge sections 3.1 (Flow Session Awareness) and 3.2 (Per Flow Signaling) . The PR also harmonize text with SCONE Protocol document to  use same semantics when defining a "FLOW" ie, to mean "UDP datagrams that QUIC exchanges" (remove words such as "sessions", "application flows". RE Gorry's comment on clarifying position for ECN, that is added in Section Titled "Interworking with other Congestion Management" for a better fit