### PR TITLE
Update SCONE Indication to Network Element (Issue #8)

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -123,7 +123,7 @@ to their policy objectives.
 
 ## Considerations of Processing Complexity
 As specified in Section 6.1 of {{I-D.ietf-scone-protocol}}, SCONE-aware endpoints provide
-an indication to the SCONE Network Element, enabling it to identify the SCONE-capable flow
+an specific indication on the first SCONE packet to support the identification of a SCONE-capable flow
 without any need for compute-intensive flow classification. Additionally, SCONE-capable endpoints,
 through bit-rate self-adaptation, remove the need for complex rate-limiting functions in the network
 element. Support for SCONE indication and bit-rate self-adaptation reduces complexity and CPU processing

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -121,7 +121,7 @@ throughput information. It is expected that network operators shall be able to i
 SCONE-enabled flows and, where appropriate, provide throughput advice in accordance
 to their policy objectives.
 
-## SCONE Indication to the Network Element
+## Considerations of Processing Complexity
 As specified in Section 6.1 of {{I-D.ietf-scone-protocol}}, SCONE-aware endpoints provide
 an indication to the SCONE Network Element, enabling it to identify the SCONE-capable flow
 without any need for compute-intensive flow classification. Additionally, SCONE-capable endpoints,

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -121,12 +121,13 @@ throughput information. It is expected that network operators shall be able to i
 SCONE-enabled flows and, where appropriate, provide throughput advice in accordance
 to their policy objectives.
 
-## SCONE Hint to the Network
-SCONE-aware applications ought to provide hints to the SCONE Network Elements,
-enabling it to generate appropriate throughput advice for a given
-UDP 4-tuple. Such hints prevent unnecessary default rate-limiting, allow the
-network to signal the maximum allowable bit rate, and reduce CPU
-overhead by eliminating additional classification steps.
+## SCONE Indication to the Network Element
+As specified in Section 6.1 of {{I-D.ietf-scone-protocol}}, SCONE-aware endpoints provide
+an indication to the SCONE Network Element, enabling it to identify the SCONE-capable flow
+without any need for compute-intensive flow classification. Additionally, SCONE-capable endpoints,
+through bit-rate self-adaptation, remove the need for complex rate-limiting functions in the network
+element. Support for SCONE indication and bit-rate self-adaptation reduces complexity and CPU processing
+load in the network element.
 
 ## Retransmission of Advised Bit-Rate
 Packet loss or non-delivery of SCONE advice reduces its effectiveness. Both

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -123,7 +123,7 @@ to their policy objectives.
 
 ## Considerations of Processing Complexity
 As specified in Section 6.1 of {{I-D.ietf-scone-protocol}}, SCONE-aware endpoints provide
-an specific indication on the first SCONE packet to support the identification of a SCONE-capable flow
+a specific indication on the first SCONE packet to support the identification of a SCONE-capable flow
 without any need for compute-intensive flow classification. Additionally, SCONE-capable endpoints,
 through bit-rate self-adaptation, remove the need for complex rate-limiting functions in the network
 element. Support for SCONE indication and bit-rate self-adaptation reduces complexity and CPU processing


### PR DESCRIPTION
GitHub Issue #8. Edit SCONE Indication to Network Element with clarifying text to align with SCONE Protocol. (Previously titled SCONE Hint to the Network Element). Adds a simple statement that SCONE-aware endpoints provide an indication to the SCONE Network Element, enabling it to identify the SCONE-capable flow without any need for compute-intensive flow classification.