### PR TITLE
Expand "Standards Compliance" Section

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -171,8 +171,25 @@ implemented in a SCONE Network Element but may also be implemented
 elsewhere in the network.
 
 ## Standards Compliance
-SCONE signaling is expected to traverse the existing data path associated
-with the UDP 4-tuple flow for which the Network Element intends to send the advisory bit-rate.
+Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE signaling
+operates entirely in-band. It does not introduce any additional routing overhead or
+require the creation of out-of-band signaling interfaces. Instead, SCONE signaling
+inherently traverses the already established network path, such as the existing
+connection between a user device and a network gateway, associated with the QUIC flow
+for which the network element intends to send throughput advice. This ensures that
+SCONE seamlessly integrates into existing architectures without requiring new tunnels
+or data paths to be established.
+
+By providing a standardized and scalable mechanism, SCONE allows network operators
+and QUIC endpoints to exchange bit-rate information without custom APIs or per-network
+integrations. SCONE improves user experience by enabling the network to provide bit-rate
+guidance directly to applications, allowing them to self-adapt instead of relying on
+network rate limiters such as policers or shapers. This avoids packet drops and throttling,
+resulting in better Quality of Experience (QoE) (see Section 7.3 of {{I-D.ietf-scone-protocol}}).
+It also supports dynamic bit-rate updates, allowing the network to adjust the maximum allowed
+bit-rate for an active flow in real-time, enabling multiple network operator business use cases
+where controlled flow rates are required. At the same time, SCONE enables transparent and
+cooperative enforcement of tiered subscriber data plans (see Section 3.2 of {{I-D.ietf-scone-protocol}}).
 
 ## Interworking with Other Congestion Management Mechanisms
 SCONE is distinct from transport-level congestion control mechanisms, such as

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -129,10 +129,16 @@ network to signal the maximum allowable bit rate, and reduce CPU
 overhead by eliminating additional classification steps.
 
 ## Retransmission of Advised Bit-Rate
-Packet loss or non-delivery of SCONE advice reduces its effectiveness. Both
-SCONE Network Elements and application endpoints should support retransmission or
-periodic re-sending of SCONE packets to ensure reliable delivery.
-Conformance depends on the behavior of both network and application endpoint.
+While endpoints send SCONE packets as frequently as they see fit to ensure
+reliable delivery, the Network Element makes independent decisions on how
+frequently to update those packets to mitigate packet loss. This decision
+relies on operational considerations such as CPU load and the nature of
+the network policies. A network enforcing dynamic policies will prioritize
+timely updates to minimize the delay in activating the advised bit-rate after
+a packet loss. Conversely, a network enforcing fixed, subscription-based
+policies that do not change over SCONE timescales can safely scale back the
+Network Element update frequency to conserve CPU resources, as timely recovery
+from packet loss is less critical.
 
 ## Frequency of Updates
 The rate at which SCONE updates are issued depends on flow

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -128,16 +128,17 @@ UDP 4-tuple. Such hints prevent unnecessary default rate-limiting, allow the
 network to signal the maximum allowable bit rate, and reduce CPU
 overhead by eliminating additional classification steps.
 
-## Retransmission of Advised Bit-Rate
-While endpoints send SCONE packets as frequently as they see fit to ensure
-reliable delivery, the network element makes independent decisions on how
-frequently to update those traversing packets. This decision relies on
-operational considerations such as CPU load and the nature of the network
-policies. A network enforcing dynamic policies might prioritize updating
-SCONE packets immediately upon a policy trigger to minimize the application's
-reaction time to the new limit. Conversely, a network enforcing fixed,
-subscription-based policies can safely scale back its update frequency to
-conserve CPU resources, provided it still updates SCONE packets periodically
+## Retransmission Rate of Advised Bit-Rate
+Packet loss or non-delivery of SCONE advice directly reduces its effectiveness.
+Because the reliable delivery of throughput advice relies entirely on the
+periodic sending of SCONE packets by application endpoints, the network element
+must make independent operational decisions on how frequently to update those
+traversing packets. This decision relies on operational considerations such as
+CPU load and the nature of the network policies. A network enforcing dynamic
+policies might prioritize updating SCONE packets immediately upon a policy trigger
+to minimize the application's reaction time to the new limit. Conversely, a network
+enforcing fixed, subscription-based policies can safely scale back its update frequency
+to conserve CPU resources, provided it still updates SCONE packets periodically
 (e.g., every 20 to 30 seconds). This periodic update frequency ensures that the
 throughput advice reliably reaches the endpoint and does not inadvertently expire
 across the standard monitoring period due to normal packet loss.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -130,15 +130,17 @@ overhead by eliminating additional classification steps.
 
 ## Retransmission of Advised Bit-Rate
 While endpoints send SCONE packets as frequently as they see fit to ensure
-reliable delivery, the Network Element makes independent decisions on how
-frequently to update those packets to mitigate packet loss. This decision
-relies on operational considerations such as CPU load and the nature of
-the network policies. A network enforcing dynamic policies will prioritize
-timely updates to minimize the delay in activating the advised bit-rate after
-a packet loss. Conversely, a network enforcing fixed, subscription-based
-policies that do not change over SCONE timescales can safely scale back the
-Network Element update frequency to conserve CPU resources, as timely recovery
-from packet loss is less critical.
+reliable delivery, the network element makes independent decisions on how
+frequently to update those traversing packets. This decision relies on
+operational considerations such as CPU load and the nature of the network
+policies. A network enforcing dynamic policies might prioritize updating
+SCONE packets immediately upon a policy trigger to minimize the application's
+reaction time to the new limit. Conversely, a network enforcing fixed,
+subscription-based policies can safely scale back its update frequency to
+conserve CPU resources, provided it still updates SCONE packets periodically
+(e.g., every 20 to 30 seconds). This periodic update frequency ensures that the
+throughput advice reliably reaches the endpoint and does not inadvertently expire
+across the standard monitoring period due to normal packet loss.
 
 ## Frequency of Updates
 The rate at which SCONE updates are issued depends on flow

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -215,7 +215,7 @@ the QUIC flow does not exceed the throughput limits set by network policy. Alter
 can deploy SCONE purely as an advisory signal without any throttling fallback, prioritizing
 cooperative application optimization over strict compliance enforcement.
 
-## Standards Compliance
+## In-Band Signaling and Network Integration
 Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE signaling
 operates entirely in-band. It does not introduce any additional routing overhead or
 require the creation of out-of-band signaling interfaces. Instead, SCONE signaling
@@ -225,16 +225,11 @@ for which the network element intends to send throughput advice. This ensures th
 SCONE seamlessly integrates into existing architectures without requiring new tunnels
 or data paths to be established.
 
-By providing a standardized and scalable mechanism, SCONE allows network operators
-and QUIC endpoints to exchange bit-rate information without custom APIs or per-network
-integrations. SCONE improves user experience by enabling the network to provide bit-rate
-guidance directly to applications, allowing them to self-adapt instead of relying on
-network rate limiters such as policers or shapers. This avoids packet drops and throttling,
-resulting in better Quality of Experience (QoE) (see Section 7.3 of {{I-D.ietf-scone-protocol}}).
-It also supports dynamic bit-rate updates, allowing the network to adjust the maximum allowed
-bit-rate for an active flow in real-time, enabling multiple network operator business use cases
-where controlled flow rates are required. At the same time, SCONE enables transparent and
-cooperative enforcement of tiered subscriber data plans (see Section 3.2 of {{I-D.ietf-scone-protocol}}).
+By providing a standardized mechanism, SCONE allows network operators and QUIC endpoints to
+exchange bit-rate information without custom APIs or per-network integrations. Applications can
+self-adapt to the advised bit-rate rather than relying on network rate limiters such as policers
+or shapers, and the network can update the advised bit-rate for an active flow, including to
+support tiered subscriber data plans (see Section 3.2 of {{I-D.ietf-scone-protocol}}).
 
 ## Interworking with Other Congestion Management Mechanisms
 SCONE throughput advice is not a substitute for congestion control mechanisms in


### PR DESCRIPTION
GitHub #22. Expanded Standards Compliance Section. For example, added text including SCONE allows network operators and QUIC endpoints to exchange bit-rate information without custom APIs or per-network integrations and provide bit-rate guidance to self-adapt instead of relying on network rate limiters such as policers or shapers.