### PR TITLE
Revert PR #31 (Dynamic Updates) pending list discussion (#24)

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -209,12 +209,15 @@ traversing packets at highly variable, application-driven intervals rather than 
 predictable or uniform signaling cadence from the network side.
 
 ## Dynamic Updates
-Target throughput advice can change dynamically while a flow is active, for example when a
-subscriber reaches a data threshold or a network policy changes. When this happens, the network
-element can immediately update the next traversing SCONE packet with the new throughput advice,
-rather than waiting for its next periodic update cadence (see Section 9.2 of
-{{I-D.ietf-scone-protocol}}). This minimizes the application's reaction time to the new network
-state.
+Dynamic rate limits updates can be enforced by the network during active
+application sessions due to:
+
+- Changes in access network type (requiring updated throughput advice)
+- Changes in Subscriber policy (e.g., exceeding usage thresholds)
+
+In such cases, the SCONE Network Elements need to be able to initiate SCONE
+packets to provide updated advice, or applications should generate SCONE
+packets frequently enough to trigger network responses.
 
 ## Presence of SCONE Network Elements On the Data Path
 When multiple SCONE-capable network elements are present on the same data path, they operate


### PR DESCRIPTION
Reverts the merge of PR #31 (Dynamic Updates).

PR #31 was merged too quickly while discussion was still open. Per the discussion with Qin, reverting to restore the prior text so the Dynamic Updates change can be revisited on the list and tracked under the reopened issue #24.
