### PR TITLE
Dynamic Updates - network element clarification for discussion (issue #24)

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -209,15 +209,12 @@ traversing packets at highly variable, application-driven intervals rather than 
 predictable or uniform signaling cadence from the network side.
 
 ## Dynamic Updates
-Dynamic rate limits updates can be enforced by the network during active
-application sessions due to:
-
-- Changes in access network type (requiring updated throughput advice)
-- Changes in Subscriber policy (e.g., exceeding usage thresholds)
-
-In such cases, the SCONE Network Elements need to be able to initiate SCONE
-packets to provide updated advice, or applications should generate SCONE
-packets frequently enough to trigger network responses.
+Target throughput advice can change dynamically while a flow is active, for example when a
+subscriber reaches a data threshold or a network policy changes. When this happens, the network
+element can update the next traversing SCONE packet with the new throughput advice (see
+Section 9.2 of {{I-D.ietf-scone-protocol}}).
+How soon the application sees the change depends on when the endpoint next sends a SCONE packet,
+since the network element cannot originate one.
 
 ## Presence of SCONE Network Elements On the Data Path
 When multiple SCONE-capable network elements are present on the same data path, they operate


### PR DESCRIPTION
Opening this for discussion under issue #24, replacing the change that was in PR #31 (merged too quickly, since backed out).

This is the proposed rework of the Dynamic Updates section. It keeps the section network-element-side and anchors the immediate-update behavior in Section 9.2 of the protocol, which permits a network element to update more often immediately after a change. It intentionally does not restate endpoint behavior already covered in Sections 5.4 (Following Throughput Advice) and 6.3 (Indications for Migrated Flows).

Please comment on the text here. Not intended for merge until there is agreement on the list / in issue #24.

Re #24.
