### PR TITLE
Issue #49, Link conformance penalty decision to Section 3.9 diagnosis…

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -266,7 +266,7 @@ the provided throughput advice, operators have flexibility in how they handle vi
 Before applying rate control mechanisms, operators can use the diagnostic approach described in
 {{monitoring-and-logging}} to confirm that the flow requires intervention
 in order to maintain target rates per {{Section 7.3 of I-D.ietf-scone-protocol}}.
-If the monitoring function detects a violation where an application is not respecting the
+If the monitoring function detects that an application is not respecting the
 signaled throughput advice, the network can employ a throttling fallback. This involves falling
 back to traditional rate-limiting mechanisms, such as dropping or delaying packets, to ensure
 the QUIC flow does not exceed the throughput limits set by network policy. Alternatively, operators

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -264,8 +264,8 @@ for their measurement and averaging period.
 Because some applications will not support SCONE, and others either will not or cannot follow
 the provided throughput advice, operators have flexibility in how they handle violations.
 Before applying rate control mechanisms, operators can use the diagnostic approach described in
-{{monitoring-and-logging}} to confirm that a sustained violation reflects application
-non-compliance rather than a delivery failure per {{Section 7.3 of I-D.ietf-scone-protocol}}.
+{{monitoring-and-logging}} to confirm that the flow requires intervention
+in order to maintain target rates per {{Section 7.3 of I-D.ietf-scone-protocol}}.
 If the monitoring function detects a violation where an application is not respecting the
 signaled throughput advice, the network can employ a throttling fallback. This involves falling
 back to traditional rate-limiting mechanisms, such as dropping or delaying packets, to ensure

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -262,7 +262,7 @@ than the baseline 67 second window ({{Section 5.2 of I-D.ietf-scone-protocol}})
 for their measurement and averaging period.
 
 Because some applications will not support SCONE, and others either will not or cannot follow
-the provided throughput advice, operators have flexibility in how they handle violations.
+the provided throughput advice, operators have flexibility in how they handle flows that exceed the limits that are set in their policies.
 Before applying rate control mechanisms, operators can use the diagnostic approach described in
 {{monitoring-and-logging}} to confirm that the flow requires intervention
 in order to maintain target rates per {{Section 7.3 of I-D.ietf-scone-protocol}}.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -225,7 +225,7 @@ its own advice. If no SCONE-capable element is present on the new path, the prev
 expires after a monitoring period ({{Section 5.4 of I-D.ietf-scone-protocol}}) and the
 application operates without SCONE-advised limits.
 
-## Monitoring and Logging
+## Monitoring and Logging {#monitoring-and-logging}
 SCONE signaling can be integrated into existing operational and
 management frameworks to enable monitoring, troubleshooting, and fault
 isolation. Metrics of interest include:
@@ -258,10 +258,14 @@ longer sliding window to account for the possibility of packet loss.
 
 To simplify the measurement function, reduce computational load, or offload this
 function to another node in the network, operators can select any value larger
-than the baseline 67-second window ({{Section 5.2 of I-D.ietf-scone-protocol}}) for their measurement and averaging period.
+than the baseline 67-second window ({{Section 5.2 of I-D.ietf-scone-protocol}})
+for their measurement and averaging period.
 
 Because some applications will not support SCONE, and others either will not or cannot follow
 the provided throughput advice, operators have flexibility in how they handle violations.
+Before applying penalties, operators can use the diagnostic approach described in
+{{monitoring-and-logging}} to confirm that a sustained violation reflects application
+non-compliance rather than a delivery failure per {{Section 7.3 of I-D.ietf-scone-protocol}}.
 If the monitoring function detects a violation where an application is not respecting the
 signaled throughput advice, the network can employ a throttling fallback. This involves falling
 back to traditional rate-limiting mechanisms, such as dropping or delaying packets, to ensure

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -258,7 +258,7 @@ longer sliding window to account for the possibility of packet loss.
 
 To simplify the measurement function, reduce computational load, or offload this
 function to another node in the network, operators can select any value larger
-than the baseline 67-second window ({{Section 5.2 of I-D.ietf-scone-protocol}})
+than the baseline 67 second window ({{Section 5.2 of I-D.ietf-scone-protocol}})
 for their measurement and averaging period.
 
 Because some applications will not support SCONE, and others either will not or cannot follow

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -267,8 +267,7 @@ Before applying rate control mechanisms, operators can use the diagnostic approa
 {{monitoring-and-logging}} to confirm that the flow requires intervention
 in order to maintain target rates per {{Section 7.3 of I-D.ietf-scone-protocol}}.
 If the monitoring function detects that an application is not respecting the
-signaled throughput advice, the network can employ a throttling fallback. This involves falling
-back to traditional rate-limiting mechanisms, such as dropping or delaying packets, to ensure
+signaled throughput advice, the network can employ traditional rate-limiting mechanisms, such as dropping or delaying packets, to ensure
 the QUIC flow does not exceed the throughput limits set by network policy. Alternatively, operators
 can deploy SCONE purely as an advisory signal without any throttling fallback, prioritizing
 cooperative application optimization over strict compliance enforcement.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -263,7 +263,7 @@ for their measurement and averaging period.
 
 Because some applications will not support SCONE, and others either will not or cannot follow
 the provided throughput advice, operators have flexibility in how they handle violations.
-Before applying penalties, operators can use the diagnostic approach described in
+Before applying rate control mechanisms, operators can use the diagnostic approach described in
 {{monitoring-and-logging}} to confirm that a sustained violation reflects application
 non-compliance rather than a delivery failure per {{Section 7.3 of I-D.ietf-scone-protocol}}.
 If the monitoring function detects a violation where an application is not respecting the


### PR DESCRIPTION
… approach

Issue #49, Add a sentence in the Conformance Monitoring (Section 3.10) linking the penalty decision to the diagnosis approach in Section 3.9 and  {{Section 7.3 of I-D.ietf-scone-protocol}}.  Add anchor to the Monitoring and Logging section heading to support the internal cross-reference.

Text of the sentence:
"Before applying penalties, operators can use the diagnostic approach described in {{monitoring-and-logging}} to confirm that a sustained violation reflects application non-compliance rather than a delivery failure per {{Section 7.3 of I-D.ietf-scone-protocol}}."