### PR TITLE
introduce new intro subsection on SCONE Protocol Overview and Network Element Function

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -116,8 +116,8 @@ This document uses terms and definitions described in {{I-D.ietf-scone-protocol}
 # Applicability, Manageability and Operational Considerations
 
 Encompassing deployment of network elements in a wide range of networks, this document
-is limited to discussing the core manageability considerations for
-the SCONE protocol to ensure its consistent and effective use across varied network paths.
+is limited to discussing the core manageability and operational considerations for
+the SCONE protocol to support its effective use across these varied network types.
 
 ## Flow Awareness and Per-Flow Signaling
 As defined in the core SCONE protocol specification {{I-D.ietf-scone-protocol}},

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -76,9 +76,9 @@ It also addresses operational, configuration, and management aspects not covered
 
 ## SCONE Protocol Overview and Network Element Function {#scone-overview}
 
-Deploying SCONE in an operator network involves the application
+Deploying SCONE in a communication network involves the application
 endpoints and any SCONE-capable network elements along the path of a
-flow. SCONE is used on a flow only when its application endpoints
+flow of QUIC UDP datagrams. SCONE is used on a QUIC flow only when its application endpoints
 support it. SCONE packets use a QUIC header with a new version number
 and are sent in the same UDP datagram as
 the end-to-end QUIC packet using the same connection ID.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -59,7 +59,7 @@ informative:
 
 
 --- abstract
-This document describes manageability considerations for network operator for providing throughput guidance to
+This document describes manageability considerations for network operators for providing throughput guidance to
 application endpoints. This guidance is specifically addressed within the context of communication
 networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -91,7 +91,13 @@ To participate in SCONE, a network element is assumed to have the
 functional capability to identify and track SCONE-compliant QUIC
 flows, recognize and process SCONE packets within those flows, and
 map network policies into throughput advice to be inserted into the
-SCONE packets.
+SCONE packets (see also {{network-integration}}.
+
+By providing a standardized mechanism, SCONE allows network operators to provide
+throughput advice information without custom APIs or per-network integrations. Applications can
+self-adapt to the advised rate rather than relying on network rate limiters such as policers
+or shapers, and the network can update the advised rate for an active flow, including to
+support tiered subscriber data plans (see {{Section 3.2 of I-D.ietf-scone-protocol}}).
 
 When on-path network elements are present between the server and the client
 application end-points, their specific configuration and role will influence the advice they
@@ -328,21 +334,17 @@ the QUIC flow does not exceed the throughput limits set by network policy. Alter
 can deploy SCONE purely as an advisory signal without any throttling fallback, prioritizing
 cooperative application optimization over strict compliance enforcement.
 
-## In-Band Signaling and Network Integration
+## Network Integration {#network-integration}
+
 Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE signaling
-operates entirely in-band. It does not introduce any additional routing overhead or
-require the creation of out-of-band signaling interfaces. Instead, SCONE signaling
+operates entirely in-band. SCONE signaling
 inherently traverses the already established network path, such as the existing
 connection between a user device and a network gateway, associated with the QUIC flow
-for which the network element intends to send throughput advice. This ensures that
-SCONE seamlessly integrates into existing architectures without requiring new tunnels
-or data paths to be established.
+for which the network element intends to send throughput advice.
+As such, SCONE seamlessly integrates into existing architectures without requiring 
+new data paths, e.g. using tunnels, nor introducing any additional routing overhead.
+Similarly, operators are not required to deploy any additional out-of-band signaling interfaces. 
 
-By providing a standardized mechanism, SCONE allows network operators to provide
-throughput advice information without custom APIs or per-network integrations. Applications can
-self-adapt to the advised rate rather than relying on network rate limiters such as policers
-or shapers, and the network can update the advised rate for an active flow, including to
-support tiered subscriber data plans (see {{Section 3.2 of I-D.ietf-scone-protocol}}).
 
 ## Interworking with Other Congestion Management Mechanisms
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -95,9 +95,9 @@ map network policies into throughput advice to be inserted into the
 SCONE packets.
 
 By providing a standardized mechanism, SCONE allows network operators to provide
-throughput advice information without custom APIs or per-network integrations. Applications can
-self-adapt to the advised rate rather than relying on network rate limiters such as policers
-or shapers, and the network can update the advised rate for an active flow, including to
+throughput advice information to QUIC endpoints without custom APIs or per-network integrations. Applications can
+self-adapt to the advised bitrate rather than relying on network rate limiters such as policers
+or shapers, and the network can update the advised bitrate for an active flow, including to
 support tiered subscriber data plans (see {{Section 3.2 of I-D.ietf-scone-protocol}}).
 
 When on-path network elements are present between the server and the client

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -340,9 +340,10 @@ Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE sig
 operates entirely in-band. SCONE signaling
 inherently traverses the already established network path, such as the existing
 connection between a user device and a network gateway, associated with the QUIC flow
-for which the network element intends to send throughput advice. This ensures that
-SCONE seamlessly integrates into existing architectures without requiring new tunnels
-or data paths to be established.
+for which the network element intends to send throughput advice. As such,
+SCONE seamlessly integrates into existing architectures without requiring
+new data paths, e.g. using tunnels, nor introducing any additional routing overhead.
+Similarly, operators are not required to deploy any additional out-of-band signaling interfaces.
 
 
 ## Interworking with Other Congestion Management Mechanisms

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -60,14 +60,14 @@ informative:
 
 --- abstract
 This document describes the Applicability and Manageability considerations for network operators for providing throughput guidance to
-application endpoints. This guidance is specifically addressed within the context of communication
-networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
+application endpoints. This guidance is specifically addressed within the context of telecommunication service
+provider networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
 
 --- middle
 
 # Introduction
 
-The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit to application endpoints via SCONE packets in the communication networks.
+The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit rate to application endpoints via SCONE packets in the telecommunications service provider networks.
 
 Network elements can provide notifications of the advisory maximum sustainable rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
 mechanisms, to proactively align their transmission rates with network policies. This document provides

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -1,5 +1,5 @@
 ---
-title: "Manageability Considerations for SCONE"
+title: "Applicability & Manageability Considerations for SCONE"
 abbrev: "SCONE Applicability & Manageability"
 docname: draft-ietf-scone-applicability-manageability-latest
 category: info
@@ -9,7 +9,7 @@ ipr: trust200902
 area: "Web and Internet Transport"
 workgroup: "Standard Communication with Network Elements"
 
-keyword: [SCONE, access networks, bitrate, throughput advice, manageability]
+keyword: [SCONE, access networks, bit rate, throughput advice, applicability, manageability]
 
 stand_alone: yes
 smart_quotes: no
@@ -59,7 +59,7 @@ informative:
 
 
 --- abstract
-This document describes manageability considerations for network operators for providing throughput guidance to
+This document describes the Applicability and Manageability considerations for network operators for providing throughput guidance to
 application endpoints. This guidance is specifically addressed within the context of communication
 networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
 
@@ -67,7 +67,7 @@ networks utilizing the Standard Communication with Network Elements (SCONE) prot
 
 # Introduction
 
-The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum sustainable rate, to application endpoints via SCONE packets in the communication networks.
+The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit to application endpoints via SCONE packets in the communication networks.
 
 Network elements can provide notifications of the advisory maximum sustainable rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
 mechanisms, to proactively align their transmission rates with network policies. This document provides
@@ -91,7 +91,7 @@ To participate in SCONE, a network element is assumed to have the
 functional capability to identify and track SCONE-compliant QUIC
 flows, recognize and process SCONE packets within those flows, and
 map network policies into throughput advice to be inserted into the
-SCONE packets (see also {{network-integration}}.
+SCONE packets.
 
 By providing a standardized mechanism, SCONE allows network operators to provide
 throughput advice information without custom APIs or per-network integrations. Applications can
@@ -112,7 +112,7 @@ or gateways such as the Broadband Network Gateway serving multiple devices.
 
 This document uses terms and definitions described in {{I-D.ietf-scone-protocol}}.
 
-# Manageability Considerations
+# Applicability, Manageability and Operational Considerations
 
 Encompassing deployment of network elements in a wide range of networks, this document
 is limited to discussing the core manageability considerations for
@@ -123,7 +123,7 @@ As defined in the core SCONE protocol specification {{I-D.ietf-scone-protocol}},
 throughput advice is associated with the flow of QUIC UDP datagrams sharing the
 same address tuple (IP version, source and destination IP addresses, and UDP ports).
 
-Because throughput advice applies strictly to this specific flow, SCONE network elements
+Because throughput advice applies strictly to this specific flow, SCONE Network Elements
 need to unambiguously associate their policy limits with the correct QUIC flows. However,
 the act of applying SCONE throughput advice is inherently stateless. To provide advice, a
 network element simply identifies a traversing SCONE packet and updates its value based on
@@ -296,18 +296,18 @@ makes this correlation possible, aligning with the monitoring
 guidance in {{Section 7.2 of I-D.ietf-scone-protocol}}.
 
 
-## Conformance Monitoring {#conformance-monitoring}
+## Conformance Monitoring
 Networks that choose to provide SCONE throughput advice can implement mechanisms to
-monitor QUIC flows and measure conformance to the advised rate, either per flow of
+monitor QUIC flows and measure conformance to the advised bit-rate, either per flow of
 packets on the same UDP address tuple, or in aggregate across multiple QUIC flows if they
 contribute to a shared policy limit (such as a device or network subscription level). This
-will allow operators to validate whether applications are following the advised rate.
+will allow operators to validate whether applications are following the advised bit-rate.
 
-While it is expected that operators will implement monitoring at the SCONE network element
+While it is expected that operators will implement monitoring at the SCONE Network Element
 providing the advice, it could also be performed elsewhere in the network. However, network
 elements lack the capability to validate the legitimacy of SCONE packets coalesced with other
 QUIC packets. Therefore, operators must ensure a network element evaluates conformance only
-against the advised rate that it set itself, and never enforces limits based on advice
+against the advised bit-rate that it set itself, and never enforces limits based on advice
 set by other downstream network elements.
 
 When evaluating compliance, network operators will need to account for the time required for
@@ -334,7 +334,7 @@ the QUIC flow does not exceed the throughput limits set by network policy. Alter
 can deploy SCONE purely as an advisory signal without any throttling fallback, prioritizing
 cooperative application optimization over strict compliance enforcement.
 
-## Network Integration {#network-integration}
+## In-Band Signaling and Network Integration
 
 Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE signaling
 operates entirely in-band. SCONE signaling

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -69,9 +69,10 @@ provider networks utilizing the Standard Communication with Network Elements (SC
 
 The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit rate, to application endpoints via SCONE packets in the telecommunications service provider networks.
 
-Network elements can provide notifications of the advisory maximum sustainable rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
-mechanisms, to proactively align their transmission rates with network policies. This document provides
-operational, configuration, and management aspect for deploying the SCONE protocol within provider networks.
+Network elements capable of rate limiting can send notifications of the advisory maximum allowable bit rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
+mechanisms,to proactively align their transmission rates with network policies. This document addresses the
+Applicability and Manageability considerations for deploying the SCONE protocol within service provider networks.
+It also addresses operational, configuration, and management aspects not covered in the core protocol specification.
 
 ## SCONE Protocol Overview and Network Element Function
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -133,8 +133,7 @@ per-flow state.
 
 While the signaling itself is stateless, managing the operational lifecycle of a SCONE
 deployment may require establishing and maintaining per-flow context. Specifically, to execute
-the monitoring, logging, and conformance evaluation functions detailed later in this document
-(see {{conformance-monitoring}}),
+the monitoring, logging, and conformance evaluation functions detailed later in this document,
 the network element has to track the flow's throughput over multiple monitoring periods. This
 per-flow context serves as the operational foundation for validating whether an application is
 adhering to the advised rate and for applying any potentially necessary policy enforcement.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -1,5 +1,5 @@
 ---
-title: "Applicability & Manageability Considerations for SCONE"
+title: "Manageability Considerations for SCONE"
 abbrev: "SCONE Applicability & Manageability"
 docname: draft-ietf-scone-applicability-manageability-latest
 category: info
@@ -9,7 +9,7 @@ ipr: trust200902
 area: "Web and Internet Transport"
 workgroup: "Standard Communication with Network Elements"
 
-keyword: [SCONE, access networks, bit rate, throughput advice, applicability, manageability]
+keyword: [SCONE, access networks, bitrate, throughput advice, manageability]
 
 stand_alone: yes
 smart_quotes: no

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -132,11 +132,11 @@ the configured policy for that flow or network scope, without needing to maintai
 per-flow state.
 
 While the signaling itself is stateless, managing the operational lifecycle of a SCONE
-deployment may require establishing and maintaining per-flow context. Specifically, to execute
+deployment requires establishing and maintaining per-flow context. Specifically, to execute
 the monitoring, logging, and conformance evaluation functions detailed later in this document,
-the network element has to track the flow's throughput over multiple monitoring periods. This
+the network element must track the flow's throughput over multiple monitoring periods. This
 per-flow context serves as the operational foundation for validating whether an application is
-adhering to the advised rate and for applying any potentially necessary policy enforcement.
+adhering to the advised rate and for applying any necessary policy enforcement.
 
 ## Determining Throughput Constraints
 The specific algorithms used to calculate throughput advice are highly

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -60,7 +60,7 @@ informative:
 
 --- abstract
 This document describes the Applicability and Manageability considerations for network operators for providing throughput guidance to
-application endpoints. This guidance is specifically addressed within the context of telecommunication service
+application endpoints. This guidance is specifically addressed within the context of telecommunications service
 provider networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
 
 --- middle

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -74,7 +74,7 @@ mechanisms,to proactively align their transmission rates with network policies. 
 Applicability and Manageability considerations for deploying the SCONE protocol within service provider networks.
 It also addresses operational, configuration, and management aspects not covered in the core protocol specification.
 
-## SCONE Protocol Overview and Network Element Function
+## SCONE Protocol Overview and Network Element Function {#scone-overview}
 
 Deploying SCONE in an operator network involves the application
 endpoints and any SCONE-capable network elements along the path of a

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -257,9 +257,9 @@ SCONE network elements independently, without building integration between them.
 The on-path network element can change when an application changes its access network, for
 example during QUIC connection migration or a mobility event where the IP address is unchanged.
 Because SCONE signaling is stateless, this transition needs no explicit teardown or state
-transfer between the old and new network elements.
-As defined in {{Section 6.3 of I-D.ietf-scone-protocol}}, the endpoint is expected to send
-SCONE packets early on the new path, so the new network element can detect the flow and provide
+transfer between the old and new network elements. The endpoint and network elements follow the
+migration steps defined in {{Section 6.3 of I-D.ietf-scone-protocol}}, where the endpoint sends
+SCONE packets early on the new path so a network element there can detect the flow and provide
 its own advice. If no SCONE-capable element is present on the new path, the previous advice
 expires after a monitoring period ({{Section 5.4 of I-D.ietf-scone-protocol}}) and the
 application operates without SCONE-advised limits.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -249,10 +249,10 @@ since the network element cannot originate one.
 ## Presence of SCONE Network Elements On the Data Path
 When multiple SCONE-capable network elements are present on the same data path, they operate
 independently, with no synchronization or control-plane coordination required between them.
-This is possible because each network element is expected to only lowers the rate signal,
-preserving any lower advice already set by
+Each network element only lowers the rate signal, preserving any lower advice already set by
 another element on the path, so the endpoint applies the most restrictive advice along the
-path (see {{Section 5.4 of I-D.ietf-scone-protocol}}).
+path (see {{Section 5.4 of I-D.ietf-scone-protocol}}). This lets operators deploy and manage
+SCONE network elements independently, without building integration between them.
 
 ## Change of Network Element During an Active Flow
 The on-path network element can change when an application changes its access network, for

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -70,7 +70,7 @@ networks utilizing the Standard Communication with Network Elements (SCONE) prot
 The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum sustainable rate, to application endpoints via SCONE packets in the communication networks.
 
 Network elements can provide notifications of the advisory maximum sustainable rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
-mechanisms, to proactively align their transmission rates with network policies. This document provides 
+mechanisms, to proactively align their transmission rates with network policies. This document provides
 operational, configuration, and management aspect for deploying the SCONE protocol within provider networks.
 
 ## SCONE Protocol Overview and Network Element Function
@@ -78,7 +78,7 @@ operational, configuration, and management aspect for deploying the SCONE protoc
 Deploying SCONE in an operator network involves the application
 endpoints and any SCONE-capable network elements along the path of a
 flow. SCONE is used on a flow only when its application endpoints
-support it. SCONE packets use a QUIC header with a new version number 
+support it. SCONE packets use a QUIC header with a new version number
 and are sent in the same UDP datagram as
 the end-to-end QUIC packet using the same connection ID.
 This ensures that network elements that forward QUIC packets also forward
@@ -252,13 +252,13 @@ independently, with no synchronization or control-plane coordination required be
 This is possible because each network element is expected to only lowers the rate signal,
 preserving any lower advice already set by
 another element on the path, so the endpoint applies the most restrictive advice along the
-path (see {{Section 5.4 of I-D.ietf-scone-protocol}}). 
+path (see {{Section 5.4 of I-D.ietf-scone-protocol}}).
 
 ## Change of Network Element During an Active Flow
 The on-path network element can change when an application changes its access network, for
 example during QUIC connection migration or a mobility event where the IP address is unchanged.
 Because SCONE signaling is stateless, this transition needs no explicit teardown or state
-transfer between the old and new network elements. 
+transfer between the old and new network elements.
 As defined in {{Section 6.3 of I-D.ietf-scone-protocol}}, the endpoint is expected to send
 SCONE packets early on the new path, so the new network element can detect the flow and provide
 its own advice. If no SCONE-capable element is present on the new path, the previous advice
@@ -341,9 +341,9 @@ operates entirely in-band. SCONE signaling
 inherently traverses the already established network path, such as the existing
 connection between a user device and a network gateway, associated with the QUIC flow
 for which the network element intends to send throughput advice.
-As such, SCONE seamlessly integrates into existing architectures without requiring 
+As such, SCONE seamlessly integrates into existing architectures without requiring
 new data paths, e.g. using tunnels, nor introducing any additional routing overhead.
-Similarly, operators are not required to deploy any additional out-of-band signaling interfaces. 
+Similarly, operators are not required to deploy any additional out-of-band signaling interfaces.
 
 
 ## Interworking with Other Congestion Management Mechanisms
@@ -352,15 +352,15 @@ As stated in {{Section 3.1 of I-D.ietf-scone-protocol}},
 SCONE throughput advice is not a substitute for congestion control
 utilizing congestion signals such as packet loss based on transport acknowledgments, delay, or
 Explicit Congestion Notification (ECN) {{RFC3168}} as also used by Low Latency, Low Loss, and Scalable
-Throughput (L4S) {{RFC9330}}. Rather, they are complementary. 
+Throughput (L4S) {{RFC9330}}. Rather, they are complementary.
 
-Congestion control applies a throughput limit different from the signaled SCONE advice. 
+Congestion control applies a throughput limit different from the signaled SCONE advice.
 Congestion control manages the immediate dynamics of the bottleneck
-link, while SCONE informs the application of the maximum rate allowed by network policy. 
+link, while SCONE informs the application of the maximum rate allowed by network policy.
 As such, congestion signals provide real-time
 information on transient congestion for a network path, as input for congestion control that typically operates
 on the time scale of a round-trip time (RTT). In contrast, SCONE throughput advice operates
-over a much longer period. 
+over a much longer period.
 Often, the throughput advice is expected to be below the
 congestion limit and when the application adheres to the advice, congestion control would be
 application-limited and not go into action. However, in cases of high load, congestion control would
@@ -374,7 +374,7 @@ are expected to provide this information independent of
 instantaneous link congestion. It is then up to the applications, such as adaptive bitrate video
 clients or bulk downloads, to utilize this advice according to their specific use cases.
 
-Network operators can deploy SCONE alongside L4S or standard ECN as two 
+Network operators can deploy SCONE alongside L4S or standard ECN as two
 independent network functions. Real-time congestion feedback mechanisms remain outside the SCONE domain
 as SCONE advice is carried within the QUIC payload, which does not interact
 with or modify ECN markings of the IP-layer ECN field.

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -340,10 +340,9 @@ Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE sig
 operates entirely in-band. SCONE signaling
 inherently traverses the already established network path, such as the existing
 connection between a user device and a network gateway, associated with the QUIC flow
-for which the network element intends to send throughput advice.
-As such, SCONE seamlessly integrates into existing architectures without requiring
-new data paths, e.g. using tunnels, nor introducing any additional routing overhead.
-Similarly, operators are not required to deploy any additional out-of-band signaling interfaces.
+for which the network element intends to send throughput advice. This ensures that
+SCONE seamlessly integrates into existing architectures without requiring new tunnels
+or data paths to be established.
 
 
 ## Interworking with Other Congestion Management Mechanisms

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -140,12 +140,11 @@ adhering to the advised rate and for applying any necessary policy enforcement.
 
 ## Determining Throughput Constraints
 The specific algorithms used to calculate throughput advice are highly
-dependent on a combination of network policies,
+dependent on an operator's network architecture. In practice, these
+constraints are often derived from a combination of network policies,
 real-time conditions where applicable, and any other business logic
 the operator applies. The inputs below are illustrative and will likely
-vary by operator, and they are not exhaustive.
-
-A SCONE-capable network
+vary by operator, and they are not exhaustive. A SCONE-capable network
 element may derive its throughput advice from one or more of the
 following:
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -59,20 +59,33 @@ informative:
 
 
 --- abstract
-This document describes the Applicability and Manageability considerations for providing throughput guidance to
-application endpoints. This guidance is specifically addressed within the context of telecommunications service
-provider networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
+This document describes manageability considerations for network operator for providing throughput guidance to
+application endpoints. This guidance is specifically addressed within the context of communication
+networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
 
 --- middle
 
 # Introduction
 
-The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit rate, to application endpoints via SCONE packets in the telecommunications service provider networks.
+The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum sustainable rate, to application endpoints via SCONE packets in the communication networks.
 
-Network elements capable of rate limiting can send notifications of the advisory maximum allowable bit rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
-mechanisms,to proactively align their transmission rates with network policies. This document addresses the
-Applicability and Manageability considerations for deploying the SCONE protocol within service provider networks.
-It also addresses operational, configuration, and management aspects not covered in the core protocol specification.
+Network elements can provide notifications of the advisory maximum sustainable rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
+mechanisms, to proactively align their transmission rates with network policies. This document provides 
+operational, configuration, and management aspect for deploying the SCONE protocol within provider networks.
+
+## SCONE Protocol Overview and Network Element Function
+
+Deploying SCONE in an operator network involves the application
+endpoints and any SCONE-capable network elements along the path of a
+flow. SCONE is used on a flow only when its application endpoints
+support it. SCONE packets use a QUIC header with a new version number 
+and are sent in the same UDP datagram as
+the end-to-end QUIC packet using the same connection ID.
+This ensures that network elements that forward QUIC packets also forward
+the SCONE packets.
+Specific network elements can
+implement a SCONE network element function that sets
+the throughput advice.
 
 To participate in SCONE, a network element is assumed to have the
 functional capability to identify and track SCONE-compliant QUIC
@@ -89,33 +102,22 @@ advice to guide ABR applications on a per-flow basis. In contrast, other environ
 such as wireline broadband or Wi-Fi, may apply policies at centralized aggregation points
 or gateways such as the Broadband Network Gateway serving multiple devices.
 
-Encompassing deployment of network elements in a wide range of networks, this document
-is limited to discussing the core Applicability and Manageability considerations for
-the SCONE protocol to ensure its consistent and effective use across varied network paths.
-
-
 # Terms and Definitions
 
 This document uses terms and definitions described in {{I-D.ietf-scone-protocol}}.
 
-# Applicability, Manageability and Operational Considerations
+# Manageability Considerations
 
-Deploying SCONE in an operator network involves the application
-endpoints and any SCONE-capable network elements along the path of a
-flow. SCONE is used on a flow only when its application endpoints
-support it. Network elements that forward QUIC packets also forward
-the SCONE packets carried among them, and specific network elements
-implement and configure the SCONE Network Element function that sets
-the throughput advice. This document as a whole covers the
-applicability, manageability, and operational considerations for
-deploying SCONE in such networks.
+Encompassing deployment of network elements in a wide range of networks, this document
+is limited to discussing the core manageability considerations for
+the SCONE protocol to ensure its consistent and effective use across varied network paths.
 
 ## Flow Awareness and Per-Flow Signaling
 As defined in the core SCONE protocol specification {{I-D.ietf-scone-protocol}},
 throughput advice is associated with the flow of QUIC UDP datagrams sharing the
 same address tuple (IP version, source and destination IP addresses, and UDP ports).
 
-Because throughput advice applies strictly to this specific flow, SCONE Network Elements
+Because throughput advice applies strictly to this specific flow, SCONE network elements
 need to unambiguously associate their policy limits with the correct QUIC flows. However,
 the act of applying SCONE throughput advice is inherently stateless. To provide advice, a
 network element simply identifies a traversing SCONE packet and updates its value based on
@@ -123,19 +125,21 @@ the configured policy for that flow or network scope, without needing to maintai
 per-flow state.
 
 While the signaling itself is stateless, managing the operational lifecycle of a SCONE
-deployment requires establishing and maintaining per-flow context. Specifically, to execute
-the monitoring, logging, and conformance evaluation functions detailed later in this document,
-the network element must track the flow's throughput over multiple monitoring periods. This
+deployment may require establishing and maintaining per-flow context. Specifically, to execute
+the monitoring, logging, and conformance evaluation functions detailed later in this document
+(see {{conformance-monitoring}}),
+the network element has to track the flow's throughput over multiple monitoring periods. This
 per-flow context serves as the operational foundation for validating whether an application is
-adhering to the advised rate and for applying any necessary policy enforcement.
+adhering to the advised rate and for applying any potentially necessary policy enforcement.
 
 ## Determining Throughput Constraints
 The specific algorithms used to calculate throughput advice are highly
-dependent on an operator's network architecture. In practice, these
-constraints are often derived from a combination of network policies,
+dependent on a combination of network policies,
 real-time conditions where applicable, and any other business logic
 the operator applies. The inputs below are illustrative and will likely
-vary by operator, and they are not exhaustive. A SCONE-capable network
+vary by operator, and they are not exhaustive.
+
+A SCONE-capable network
 element may derive its throughput advice from one or more of the
 following:
 
@@ -239,18 +243,18 @@ since the network element cannot originate one.
 ## Presence of SCONE Network Elements On the Data Path
 When multiple SCONE-capable network elements are present on the same data path, they operate
 independently, with no synchronization or control-plane coordination required between them.
-Each network element only lowers the rate signal, preserving any lower advice already set by
+This is possible because each network element is expected to only lowers the rate signal,
+preserving any lower advice already set by
 another element on the path, so the endpoint applies the most restrictive advice along the
-path (see {{Section 5.4 of I-D.ietf-scone-protocol}}). This lets operators deploy and manage
-SCONE network elements independently, without building integration between them.
+path (see {{Section 5.4 of I-D.ietf-scone-protocol}}). 
 
 ## Change of Network Element During an Active Flow
 The on-path network element can change when an application changes its access network, for
 example during QUIC connection migration or a mobility event where the IP address is unchanged.
 Because SCONE signaling is stateless, this transition needs no explicit teardown or state
-transfer between the old and new network elements. The endpoint and network elements follow the
-migration steps defined in {{Section 6.3 of I-D.ietf-scone-protocol}}, where the endpoint sends
-SCONE packets early on the new path so a network element there can detect the flow and provide
+transfer between the old and new network elements. 
+As defined in {{Section 6.3 of I-D.ietf-scone-protocol}}, the endpoint is expected to send
+SCONE packets early on the new path, so the new network element can detect the flow and provide
 its own advice. If no SCONE-capable element is present on the new path, the previous advice
 expires after a monitoring period ({{Section 5.4 of I-D.ietf-scone-protocol}}) and the
 application operates without SCONE-advised limits.
@@ -286,18 +290,18 @@ makes this correlation possible, aligning with the monitoring
 guidance in {{Section 7.2 of I-D.ietf-scone-protocol}}.
 
 
-## Conformance Monitoring
+## Conformance Monitoring {#conformance-monitoring}
 Networks that choose to provide SCONE throughput advice can implement mechanisms to
-monitor QUIC flows and measure conformance to the advised bit-rate, either per flow of
+monitor QUIC flows and measure conformance to the advised rate, either per flow of
 packets on the same UDP address tuple, or in aggregate across multiple QUIC flows if they
 contribute to a shared policy limit (such as a device or network subscription level). This
-will allow operators to validate whether applications are following the advised bit-rate.
+will allow operators to validate whether applications are following the advised rate.
 
-While it is expected that operators will implement monitoring at the SCONE Network Element
+While it is expected that operators will implement monitoring at the SCONE network element
 providing the advice, it could also be performed elsewhere in the network. However, network
 elements lack the capability to validate the legitimacy of SCONE packets coalesced with other
 QUIC packets. Therefore, operators must ensure a network element evaluates conformance only
-against the advised bit-rate that it set itself, and never enforces limits based on advice
+against the advised rate that it set itself, and never enforces limits based on advice
 set by other downstream network elements.
 
 When evaluating compliance, network operators will need to account for the time required for
@@ -334,42 +338,45 @@ for which the network element intends to send throughput advice. This ensures th
 SCONE seamlessly integrates into existing architectures without requiring new tunnels
 or data paths to be established.
 
-By providing a standardized mechanism, SCONE allows network operators and QUIC endpoints to
-exchange bit-rate information without custom APIs or per-network integrations. Applications can
-self-adapt to the advised bit-rate rather than relying on network rate limiters such as policers
-or shapers, and the network can update the advised bit-rate for an active flow, including to
+By providing a standardized mechanism, SCONE allows network operators to provide
+throughput advice information without custom APIs or per-network integrations. Applications can
+self-adapt to the advised rate rather than relying on network rate limiters such as policers
+or shapers, and the network can update the advised rate for an active flow, including to
 support tiered subscriber data plans (see {{Section 3.2 of I-D.ietf-scone-protocol}}).
 
 ## Interworking with Other Congestion Management Mechanisms
-SCONE throughput advice is not a substitute for congestion control mechanisms in
-transport protocols utilizing congestion feedback and signals such as acknowledgments,
-Explicit Congestion Notification (ECN) {{RFC3168}}, and Low Latency, Low Loss, and Scalable
-Throughput (L4S) {{RFC9330}}. Rather, they are complementary. Congestion signals provide real-time
-information on loss, delay, and transient congestion for a network path, typically operating
+
+As stated in {{Section 3.1 of I-D.ietf-scone-protocol}},
+SCONE throughput advice is not a substitute for congestion control
+utilizing congestion signals such as packet loss based on transport acknowledgments, delay, or
+Explicit Congestion Notification (ECN) {{RFC3168}} as also used by Low Latency, Low Loss, and Scalable
+Throughput (L4S) {{RFC9330}}. Rather, they are complementary. 
+
+Congestion control applies a throughput limit different from the signaled SCONE advice. 
+Congestion control manages the immediate dynamics of the bottleneck
+link, while SCONE informs the application of the maximum rate allowed by network policy. 
+As such, congestion signals provide real-time
+information on transient congestion for a network path, as input for congestion control that typically operates
 on the time scale of a round-trip time (RTT). In contrast, SCONE throughput advice operates
-over a much longer period. Because the network element is generally unaware of the specific
-application traffic, it simply provides static or dynamically adapted advice based on available
-policy information. Operators can use SCONE to communicate these maximum allowable bit-rates
-driven by video optimization, subscriber data, or load management policies, independent of
-instantaneous link congestion. It is then up to the applications, such as adaptive bitrate video
-clients or bulk downloads, to utilize this advice according to their specific use cases.
-
-For network operators considering co-deployment, SCONE throughput advice is strictly independent
-of the IP-layer ECN field. Because SCONE advice is carried within the QUIC payload, updating the
-advice does not interact with or modify ECN markings. This independence ensures that operators can
-safely deploy SCONE alongside L4S or standard ECN. Real-time congestion feedback mechanisms remain
-fully operational and function completely outside the SCONE domain.
-
-Operators should expect that congestion signals might frequently indicate a throughput limit different
-from the signaled SCONE advice. In other words, in the best case, the throughput advice is below the
+over a much longer period. 
+Often, the throughput advice is expected to be below the
 congestion limit and when the application adheres to the advice, congestion control would be
 application-limited and not go into action. However, in cases of high load, congestion control would
 limit the throughput below the provided advice, as the SCONE advice is only an upper limit. As such,
 congestion control or a similar mechanism to react to congestion, such as a circuit breaker, is always
 needed in addition to SCONE.
 
-In environments where both are present, congestion control manages the immediate dynamics of the bottleneck
-link, while SCONE informs the application of the maximum rate allowed by network policy. Network operators
+Operators can use SCONE to communicate static or dynamically adapted advice based on available
+policy information, e.g. based on subscriber data, or load management policies, and
+are expected to provide this information independent of
+instantaneous link congestion. It is then up to the applications, such as adaptive bitrate video
+clients or bulk downloads, to utilize this advice according to their specific use cases.
+
+Network operators can deploy SCONE alongside L4S or standard ECN as two 
+independent network functions. Real-time congestion feedback mechanisms remain outside the SCONE domain
+as SCONE advice is carried within the QUIC payload, which does not interact
+with or modify ECN markings of the IP-layer ECN field.
+In environments where both are present, Network operators
 will benefit from ensuring that throughput advice policies and congestion control configurations are consistent
 within scoped deployments, to avoid providing conflicting feedback to applications.
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -67,7 +67,7 @@ provider networks utilizing the Standard Communication with Network Elements (SC
 
 # Introduction
 
-The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit rate to application endpoints via SCONE packets in the telecommunications service provider networks.
+The SCONE protocol {{I-D.ietf-scone-protocol}} provides a signaling mechanism that enables on-path, SCONE-capable network elements to communicate "throughput advice", the advisory maximum allowable bit rate, to application endpoints via SCONE packets in the telecommunications service provider networks.
 
 Network elements can provide notifications of the advisory maximum sustainable rate in each direction of the observed traffic. This allows applications, particularly those using adaptive bit-rate (ABR)
 mechanisms, to proactively align their transmission rates with network policies. This document provides

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -335,15 +335,14 @@ can deploy SCONE purely as an advisory signal without any throttling fallback, p
 cooperative application optimization over strict compliance enforcement.
 
 ## In-Band Signaling and Network Integration
-
 Because SCONE packets are always coalesced with ordinary QUIC packets, SCONE signaling
-operates entirely in-band. SCONE signaling
+operates entirely in-band. It does not introduce any additional routing overhead or
+require the creation of out-of-band signaling interfaces. Instead, SCONE signaling
 inherently traverses the already established network path, such as the existing
 connection between a user device and a network gateway, associated with the QUIC flow
-for which the network element intends to send throughput advice. As such,
-SCONE seamlessly integrates into existing architectures without requiring
-new data paths, e.g. using tunnels, nor introducing any additional routing overhead.
-Similarly, operators are not required to deploy any additional out-of-band signaling interfaces.
+for which the network element intends to send throughput advice. This ensures that
+SCONE seamlessly integrates into existing architectures without requiring new tunnels
+or data paths to be established.
 
 
 ## Interworking with Other Congestion Management Mechanisms

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -79,9 +79,9 @@ It also addresses operational, configuration, and management aspects not covered
 Deploying SCONE in a communication network involves the application
 endpoints and any SCONE-capable network elements along the path of a
 flow of QUIC UDP datagrams. SCONE is used on a QUIC flow only when its application endpoints
-support it. SCONE packets use a QUIC header with a new version number
-and are sent in the same UDP datagram as
-the end-to-end QUIC packet using the same connection ID.
+support it. SCONE packets are QUIC long header packets carrying a
+SCONE-specific version number, coalesced into the same UDP datagram
+as the QUIC packets they accompany.
 This ensures that network elements that forward QUIC packets also forward
 the SCONE packets.
 Any network element can

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -347,38 +347,35 @@ Similarly, operators are not required to deploy any additional out-of-band signa
 
 
 ## Interworking with Other Congestion Management Mechanisms
-
-As stated in {{Section 3.1 of I-D.ietf-scone-protocol}},
-SCONE throughput advice is not a substitute for congestion control
-utilizing congestion signals such as packet loss based on transport acknowledgments, delay, or
-Explicit Congestion Notification (ECN) {{RFC3168}} as also used by Low Latency, Low Loss, and Scalable
-Throughput (L4S) {{RFC9330}}. Rather, they are complementary.
-
-Congestion control applies a throughput limit different from the signaled SCONE advice.
-Congestion control manages the immediate dynamics of the bottleneck
-link, while SCONE informs the application of the maximum rate allowed by network policy.
-As such, congestion signals provide real-time
-information on transient congestion for a network path, as input for congestion control that typically operates
+SCONE throughput advice is not a substitute for congestion control mechanisms in
+transport protocols utilizing congestion feedback and signals such as acknowledgments,
+Explicit Congestion Notification (ECN) {{RFC3168}}, and Low Latency, Low Loss, and Scalable
+Throughput (L4S) {{RFC9330}}. Rather, they are complementary. Congestion signals provide real-time
+information on loss, delay, and transient congestion for a network path, typically operating
 on the time scale of a round-trip time (RTT). In contrast, SCONE throughput advice operates
-over a much longer period.
-Often, the throughput advice is expected to be below the
+over a much longer period. Because the network element is generally unaware of the specific
+application traffic, it simply provides static or dynamically adapted advice based on available
+policy information. Operators can use SCONE to communicate these maximum allowable bit-rates
+driven by video optimization, subscriber data, or load management policies, independent of
+instantaneous link congestion. It is then up to the applications, such as adaptive bitrate video
+clients or bulk downloads, to utilize this advice according to their specific use cases.
+
+For network operators considering co-deployment, SCONE throughput advice is strictly independent
+of the IP-layer ECN field. Because SCONE advice is carried within the QUIC payload, updating the
+advice does not interact with or modify ECN markings. This independence ensures that operators can
+safely deploy SCONE alongside L4S or standard ECN. Real-time congestion feedback mechanisms remain
+fully operational and function completely outside the SCONE domain.
+
+Operators should expect that congestion signals might frequently indicate a throughput limit different
+from the signaled SCONE advice. In other words, in the best case, the throughput advice is below the
 congestion limit and when the application adheres to the advice, congestion control would be
 application-limited and not go into action. However, in cases of high load, congestion control would
 limit the throughput below the provided advice, as the SCONE advice is only an upper limit. As such,
 congestion control or a similar mechanism to react to congestion, such as a circuit breaker, is always
 needed in addition to SCONE.
 
-Operators can use SCONE to communicate static or dynamically adapted advice based on available
-policy information, e.g. based on subscriber data, or load management policies, and
-are expected to provide this information independent of
-instantaneous link congestion. It is then up to the applications, such as adaptive bitrate video
-clients or bulk downloads, to utilize this advice according to their specific use cases.
-
-Network operators can deploy SCONE alongside L4S or standard ECN as two
-independent network functions. Real-time congestion feedback mechanisms remain outside the SCONE domain
-as SCONE advice is carried within the QUIC payload, which does not interact
-with or modify ECN markings of the IP-layer ECN field.
-In environments where both are present, Network operators
+In environments where both are present, congestion control manages the immediate dynamics of the bottleneck
+link, while SCONE informs the application of the maximum rate allowed by network policy. Network operators
 will benefit from ensuring that throughput advice policies and congestion control configurations are consistent
 within scoped deployments, to avoid providing conflicting feedback to applications.
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -59,7 +59,7 @@ informative:
 
 
 --- abstract
-This document describes the Applicability and Manageability considerations for network operators for providing throughput guidance to
+This document describes the Applicability and Manageability considerations for providing throughput guidance to
 application endpoints. This guidance is specifically addressed within the context of telecommunications service
 provider networks utilizing the Standard Communication with Network Elements (SCONE) protocol.
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -84,8 +84,8 @@ and are sent in the same UDP datagram as
 the end-to-end QUIC packet using the same connection ID.
 This ensures that network elements that forward QUIC packets also forward
 the SCONE packets.
-Specific network elements can
-implement a SCONE network element function that sets
+Any network element can
+implement the SCONE network element function that sets
 the throughput advice.
 
 To participate in SCONE, a network element is assumed to have the


### PR DESCRIPTION
I started this pass to remove the applicability part but besides removing the word from the title and abstract/info there was not much changes needed as all was already focused on operator advice. However, I then also did some related editorial changes many in the intro and congestion section to remove some redundancy and make the recommendation more clear and focused on operators. Sorry for merging this all together in one big PR. I hope we can work for here anyway!