### PR TITLE
Merge Reliability and Frequency of Updates, keep Dynamic Updates separate (alternative to #62)

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -215,8 +215,8 @@ advice goes unheard during any single window. A network enforcing fixed,
 subscription-based policies can typically rely on this baseline, since the
 applicable policy for a flow does not usually change once established. In
 practice, the network element can only update advice when a SCONE packet
-is available to modify. If none arrives once the chosen interval has
-elapsed, the network element waits for the next one, and that arrival is
+is available to modify. When the interval has
+elapsed, the network element waits for the next SCONE packet, and that arrival is
 what sets the real interval between updates.
 
 ## Sending Updates for Dynamic Target Throughput Changes

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -221,7 +221,7 @@ what sets the real interval between updates.
 
 ## Sending Updates for Dynamic Target Throughput Changes
 Target throughput advice can change while a flow is active, for example when a
-subscriber reaches a data threshold, or when a network policy or capacity
+subscriber reaches a data threshold or when the radio access technology or capacity
 allocation changes while the flow is already established. When this happens,
 the network element prioritizes updating the next traversing SCONE packet
 promptly, bypassing its scheduled periodic update interval, to minimize the

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -215,22 +215,14 @@ advice goes unheard during any single window. A network enforcing fixed,
 subscription-based policies can typically rely on this baseline, since the
 applicable policy for a flow does not usually change once established.
 
-Whatever interval an operator selects, the network element can only act on
-it when a SCONE packet is actually available to update. If none arrives
-exactly when the operator's interval elapses, the network element has to
-wait for the next one, so the effective update interval in practice is
-set jointly by the operator's chosen setting and the endpoint's own
-packet cadence.
-
-## Sending Updates for Dynamic Target Throughput Changes
+## Dynamic Updates
 Target throughput advice can change while a flow is active, for example when a
 subscriber reaches a data threshold, or when a network-wide policy such as a
 time-of-day or congestion-based limit takes effect while the flow is already
-established. When the target throughput changes, the network element does
-not wait for its own selected update interval to expire. Instead, it updates
-the next traversing SCONE packet as soon as one arrives, to minimize the
-application's reaction time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
-How soon the application sees the change still depends on when the endpoint next sends a SCONE packet,
+established. When this happens, the network element prioritizes updating the
+next traversing SCONE packet promptly, to minimize the application's reaction
+time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
+How soon the application sees the change depends on when the endpoint next sends a SCONE packet,
 since the network element cannot originate one.
 
 ## Presence of SCONE Network Elements On the Data Path

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -196,43 +196,32 @@ policy decisions. Network element implementations can provide the
 configuration options through which operators define and adjust
 that policy.
 
-## Reliability and Mitigating Packet Loss
-Packet loss or non-delivery of SCONE advice directly reduces its effectiveness.
-Because the reliable delivery of throughput advice relies entirely on the periodic
-sending of SCONE packets by application endpoints. {{Section 7.1 of I-D.ietf-scone-protocol}}
-("Applying Throughput Advice Signals") leaves the exact update frequency flexible. This flexibility allows operators to
-manage the tension between signaling reliability and network CPU load.
+## Reliability of Throughput Advice Delivery
+The frequency at which SCONE packets arrive at a network element is set by the
+application endpoint, not the network, and varies by application type and
+traffic pattern ({{Section 7.1 of I-D.ietf-scone-protocol}}, "Applying
+Throughput Advice Signals"). A network element cannot expect a predictable or
+uniform signaling cadence from the traffic itself, and instead decides its own
+update interval within that flexibility.
 
-A SCONE-enabled network element updates advice in SCONE packets at least twice per the
-67-second monitoring period ({{Section 5.2 of I-D.ietf-scone-protocol}},
-approximately every 20 to 30 seconds), but operators may
-choose to process and update SCONE packets more frequently to better mitigate packet losses
-or to ensure timely notifications to the application. Therefore, the network element needs
-to make independent operational decisions on how frequently to update those traversing packets.
-A network enforcing dynamic policies might prioritize updating SCONE packets immediately upon a
-policy trigger to minimize the application's reaction time to the new limit. Conversely, a network
-enforcing fixed, subscription-based policies can safely scale back its update frequency to the 20
-to 30-second baseline to conserve CPU resources. This baseline periodic update frequency ensures
-that the throughput advice reliably reaches the endpoint and does not inadvertently expire across
-the standard 67-second monitoring period due to normal packet loss.
-
-Operators balancing this reliability against network element overhead can refer to
-{{freq-updates}} and {{processing-complexity}} for further guidance.
-
-## Frequency of Updates {#freq-updates}
-For network operators, understanding that SCONE signaling is fundamentally decided by the
-application endpoint is critical. Because a SCONE Network Element relies entirely on these
-endpoint-generated packets to communicate throughput advice, the frequency of traversing SCONE
-packets varies depending on the specific application type and its traffic
-characteristics. Consequently, network elements need to be prepared to apply updates to
-traversing packets at highly variable, application-driven intervals rather than expecting a
-predictable or uniform signaling cadence from the network side.
+A SCONE-enabled network element updates advice in SCONE packets at least twice
+per the 67-second monitoring period ({{Section 5.2 of I-D.ietf-scone-protocol}},
+approximately every 20 to 30 seconds). This baseline ensures advice reliably
+reaches the endpoint and does not expire across the monitoring period, since
+SCONE packets are not delivered reliably for a variety of reasons. Operators
+may choose to update more frequently than this baseline, at the cost of
+additional network element CPU load, in exchange for a lower chance that
+advice goes unheard during any single window. A network enforcing fixed,
+subscription-based policies can typically rely on this baseline, since the
+applicable policy for a flow does not usually change once established.
 
 ## Dynamic Updates
-Target throughput advice can change dynamically while a flow is active, for example when a
-subscriber reaches a data threshold or a network policy changes. When this happens, the network
-element can update the next traversing SCONE packet with the new throughput advice (see
-{{Section 9.2 of I-D.ietf-scone-protocol}}).
+Target throughput advice can change while a flow is active, for example when a
+subscriber reaches a data threshold, or when a network-wide policy such as a
+time-of-day or congestion-based limit takes effect while the flow is already
+established. When this happens, the network element prioritizes updating the
+next traversing SCONE packet promptly, to minimize the application's reaction
+time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
 How soon the application sees the change depends on when the endpoint next sends a SCONE packet,
 since the network element cannot originate one.
 

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -215,14 +215,22 @@ advice goes unheard during any single window. A network enforcing fixed,
 subscription-based policies can typically rely on this baseline, since the
 applicable policy for a flow does not usually change once established.
 
-## Dynamic Updates
+Whatever interval an operator selects, the network element can only act on
+it when a SCONE packet is actually available to update. If none arrives
+exactly when the operator's interval elapses, the network element has to
+wait for the next one, so the effective update interval in practice is
+set jointly by the operator's chosen setting and the endpoint's own
+packet cadence.
+
+## Sending Updates for Dynamic Target Throughput Changes
 Target throughput advice can change while a flow is active, for example when a
 subscriber reaches a data threshold, or when a network-wide policy such as a
 time-of-day or congestion-based limit takes effect while the flow is already
-established. When this happens, the network element prioritizes updating the
-next traversing SCONE packet promptly, to minimize the application's reaction
-time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
-How soon the application sees the change depends on when the endpoint next sends a SCONE packet,
+established. When the target throughput changes, the network element does
+not wait for its own selected update interval to expire. Instead, it updates
+the next traversing SCONE packet as soon as one arrives, to minimize the
+application's reaction time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
+How soon the application sees the change still depends on when the endpoint next sends a SCONE packet,
 since the network element cannot originate one.
 
 ## Presence of SCONE Network Elements On the Data Path

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -221,8 +221,9 @@ what sets the real interval between updates.
 
 ## Sending Updates for Dynamic Target Throughput Changes
 Target throughput advice can change while a flow is active, for example when a
-subscriber reaches a data threshold or when the radio access technology or capacity
-allocation changes while the flow is already established. When this happens,
+subscriber reaches a data threshold or when the radio access technology changes
+or when the bandwidth allocated to the subscriber or the bearer changes
+while the flow is already established. When this happens,
 the network element prioritizes updating the next traversing SCONE packet
 promptly, bypassing its scheduled periodic update interval, to minimize the
 application's reaction time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -213,15 +213,19 @@ may choose to update more frequently than this baseline, at the cost of
 additional network element CPU load, in exchange for a lower chance that
 advice goes unheard during any single window. A network enforcing fixed,
 subscription-based policies can typically rely on this baseline, since the
-applicable policy for a flow does not usually change once established.
+applicable policy for a flow does not usually change once established. In
+practice, the network element can only update advice when a SCONE packet
+is available to modify. If none arrives once the chosen interval has
+elapsed, the network element waits for the next one, and that arrival is
+what sets the real interval between updates.
 
-## Dynamic Updates
+## Sending Updates for Dynamic Target Throughput Changes
 Target throughput advice can change while a flow is active, for example when a
-subscriber reaches a data threshold, or when a network-wide policy such as a
-time-of-day or congestion-based limit takes effect while the flow is already
-established. When this happens, the network element prioritizes updating the
-next traversing SCONE packet promptly, to minimize the application's reaction
-time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
+subscriber reaches a data threshold, or when a network policy or capacity
+allocation changes while the flow is already established. When this happens,
+the network element prioritizes updating the next traversing SCONE packet
+promptly, bypassing its scheduled periodic update interval, to minimize the
+application's reaction time to the new limit (see {{Section 9.2 of I-D.ietf-scone-protocol}}).
 How soon the application sees the change depends on when the endpoint next sends a SCONE packet,
 since the network element cannot originate one.
 


### PR DESCRIPTION
Alternative to #62, submitted for comparison, not intended to merge
until we have compared it against #62 and settled on a direction. See
the heads-up comment on #62 for context.

Merges Reliability and Mitigating Packet Loss and Frequency of Updates
into one section, retitled "Reliability of Throughput Advice Delivery"
(drops "Mitigating Packet Loss" from the title, agreeing with @mirjak ). 

Frequency of Updates carried no independent operator guidance on its own, 
so its one fact (cadence is endpoint-controlled) becomes the opening context 
for why the network element needs its own update interval, rather than a
separate section restating it.

Keeps Dynamic Updates as its own section, since the trigger-response
guidance there (act promptly on a threshold or policy change) is
distinct in kind from the steady-state cadence guidance above it.
Restores a second trigger example, a network-wide policy taking effect
while a flow is already active, alongside the data-threshold example.

No change to any other section.
