### PR TITLE
Editorial: clarify data-plan basis in "Subscriber Policies and Data P…

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -139,9 +139,7 @@ vary by operator, and they are not exhaustive. A SCONE-capable network
 element may derive its throughput advice from one or more of the
 following:
 
-- Subscriber Policies and Data Plans: Rate limits may apply when a
-subscriber reaches a data plan threshold or usage cap, and the network
-element bases its throughput advice on that subscriber policy.
+- Subscriber Policies and Data Plans: The network element bases its throughput advice on the subscriber's data plan. This includes cases where rate limits apply once a subscriber's data volume usage reaches a threshold or usage cap.
 
 - Application-Specific Policies: Operators may set maximum bit-rates for
 certain types of traffic based on subscription tier or device type, for


### PR DESCRIPTION

Editorial change only — no technical/normative change. In "Determining Throughput Constraints" → "Subscriber Policies and Data Plans", the existing sentence describes throughput advice only in terms of rate limits at a threshold/cap. This rephrasing first states the general case (advice is based on the subscriber's data plan) and then presents rate limits as an additional, more specific case, which reads more clearly.