### PR TITLE
Re submit PR#73 after rephrasing it.

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -210,7 +210,7 @@ application endpoint, not the network, and varies by application type and
 traffic pattern ({{Section 7.1 of I-D.ietf-scone-protocol}}, "Applying
 Throughput Advice Signals"). A network element cannot expect a predictable or
 uniform signaling cadence from the traffic itself, and instead decides its own
-update interval within that flexibility. However it is allowed to the application end point to decide on the SCONE packet sending frequency, it can send SCONE packets at lower frequency if it helps manage the network element's SCONE packet update processing load. 
+update interval within that flexibility. However it is allowed to the application end point to decide on the SCONE packet sending frequency, it can send SCONE packets at lower frequency if it helps manage the processing load on the SCONE network element.
 
 A SCONE-enabled network element updates advice in SCONE packets at least twice
 per the 67-second monitoring period ({{Section 5.2 of I-D.ietf-scone-protocol}},

--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -210,7 +210,7 @@ application endpoint, not the network, and varies by application type and
 traffic pattern ({{Section 7.1 of I-D.ietf-scone-protocol}}, "Applying
 Throughput Advice Signals"). A network element cannot expect a predictable or
 uniform signaling cadence from the traffic itself, and instead decides its own
-update interval within that flexibility.
+update interval within that flexibility. However it is allowed to the application end point to decide on the SCONE packet sending frequency, it can send SCONE packets at lower frequency if it helps manage the network element's SCONE packet update processing load. 
 
 A SCONE-enabled network element updates advice in SCONE packets at least twice
 per the 67-second monitoring period ({{Section 5.2 of I-D.ietf-scone-protocol}},


### PR DESCRIPTION
What I wanted to add is that since it is allowed to the sender to decide on scone pkt frequency it can send it at lower frequency also. Essentially there are some CSPs who wants to n/w to mark every pkt received from server (dont want to have this logic in n/w element to skip some scone pkts) and to reduce the load on n/w element it is expected that sender ( server) to send pkt at lower frequency (mutually agreed).  Through this PR I added some text towards this w/o getting into specifics .