### PR TITLE
Fix capitalization: conformance measurement (lowercase) per Mirja's PR #76 comment

### DIFF
--- a/draft-ietf-scone-applicability-manageability.md
+++ b/draft-ietf-scone-applicability-manageability.md
@@ -317,10 +317,10 @@ for their measurement and averaging period.
 
 Because some applications will not support SCONE, and others either will not or cannot follow
 the provided throughput advice, operators have flexibility in how they handle flows that exceed the limits that are set in their policies.
-Before applying rate-limiting (throttling) mechanisms on SCONE-capable flows, operators can use Conformance measurement and/or diagnostic approach described in
+Before applying rate-limiting (throttling) mechanisms on SCONE-capable flows, operators can use conformance measurement and/or diagnostic approach described in
 {{monitoring-and-logging}} to check that the flow requires intervention
 in order to maintain target rates per {{Section 7.3 of I-D.ietf-scone-protocol}}.
-If the Conformance measurement function detects that an application is not respecting the
+If the conformance measurement function detects that an application is not respecting the
 signaled throughput advice, the network can employ traditional rate-limiting mechanisms, such as dropping or delaying packets, to ensure
 the QUIC flow does not exceed the throughput limits set by network policy. Alternatively, operators
 can deploy SCONE purely as an advisory signal without any rate-limiting mechanism fallback, prioritizing


### PR DESCRIPTION
Small follow-up to #76 (already merged). Mirja pointed out two spots where
"Conformance measurement" should be lowercase, since it's used as a common
noun mid-sentence rather than as the section heading (which stays capitalized).

Fixes both instances in the "Flows That Exceed Throughput Advice" section.
No other content changes.

Addresses #91